### PR TITLE
Higher zs

### DIFF
--- a/carsus/io/kurucz/gfall.py
+++ b/carsus/io/kurucz/gfall.py
@@ -78,6 +78,8 @@ class GFALLReader(object):
                         'the gfall data has not been given. Defaulting to '
                         '["energy", "j"].')
             self.unique_level_identifier = self.default_unique_level_identifier
+        else:
+            self.unique_level_identifier = unique_level_identifier
 
         if ions is not None:
             self.ions = parse_selected_species(ions)

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -271,8 +271,6 @@ class NISTIonizationEnergiesIngester(BaseIngester):
             except TypeError:  # Raised when the variable is None
                 parity = None
 
-
-                
             ion.levels.append(
                 Level(data_source=self.data_source,
                       configuration=row["configuration"],

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -156,9 +156,9 @@ class NISTIonizationEnergiesParser(BaseParser):
 
             # To handle cases where the ground level J has not been understood:
             # Take as assumption J=0
-            # Consider adding a log or warning message???
             if (np.isnan(lvl["J"])):
                 lvl["J"] = '0'
+                print(f"Set J=0 for ground state of species ({row['atomic_number']}, {row['ion_charge']}).")
             
             try:
                 lvl["term"] = "".join([str(_) for _ in lvl_tokens["ls_term"]])

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -154,6 +154,12 @@ class NISTIonizationEnergiesParser(BaseParser):
             except KeyError:
                 pass
 
+            if (np.isnan(lvl["J"])):
+                lvl["J"] = '0'
+                print("HELLO!")
+
+
+            
             try:
                 lvl["term"] = "".join([str(_) for _ in lvl_tokens["ls_term"]])
                 lvl["spin_multiplicity"] = lvl_tokens["ls_term"]["mult"]
@@ -265,6 +271,8 @@ class NISTIonizationEnergiesIngester(BaseIngester):
             except TypeError:  # Raised when the variable is None
                 parity = None
 
+
+                
             ion.levels.append(
                 Level(data_source=self.data_source,
                       configuration=row["configuration"],

--- a/carsus/io/nist/ionization.py
+++ b/carsus/io/nist/ionization.py
@@ -154,11 +154,11 @@ class NISTIonizationEnergiesParser(BaseParser):
             except KeyError:
                 pass
 
+            # To handle cases where the ground level J has not been understood:
+            # Take as assumption J=0
+            # Consider adding a log or warning message???
             if (np.isnan(lvl["J"])):
                 lvl["J"] = '0'
-                print("HELLO!")
-
-
             
             try:
                 lvl["term"] = "".join([str(_) for _ in lvl_tokens["ls_term"]])

--- a/carsus/io/tests/test_ionization.py
+++ b/carsus/io/tests/test_ionization.py
@@ -5,7 +5,9 @@ from pandas.util.testing import assert_series_equal
 from numpy.testing import assert_almost_equal
 from sqlalchemy.orm import joinedload
 from carsus.model import Ion
-from carsus.io.nist.ionization import  NISTIonizationEnergiesParser, NISTIonizationEnergiesIngester
+from carsus.io.nist.ionization import (NISTIonizationEnergiesParser,
+                                       NISTIonizationEnergiesIngester,
+                                       NISTIonizationEnergies)
 
 
 test_data = """
@@ -136,3 +138,16 @@ def test_ingest_ground_levels(index, exp_j, memory_session, ioniz_energies_inges
 def test_ingest_nist_asd_ion_data(memory_session):
     ingester = NISTIonizationEnergiesIngester(memory_session, spectra="h-uuh")
     ingester.ingest(ionization_energies=True, ground_levels=True)
+
+@pytest.mark.remote_data
+def test_ground_levels_missing_j():
+    ionization_energies = NISTIonizationEnergies(spectra="Nd")
+    ground_levels = ionization_energies.get_ground_levels()
+    ground_levels = ground_levels.set_index(['atomic_number', 'ion_charge'])
+
+    assert ground_levels.loc[(60, 5)]['g'] == 1
+    assert ground_levels.loc[(60, 6)]['g'] == 1
+    assert ground_levels.loc[(60, 7)]['g'] == 1
+    assert ground_levels.loc[(60, 8)]['g'] == 1
+    assert ground_levels.loc[(60, 9)]['g'] == 1
+    assert ground_levels.loc[(60, 10)]['g'] == 1

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -1,4 +1,4 @@
-name: carsus_2020
+name: carsus
 
 channels:
     - conda-forge

--- a/carsus_env3.yml
+++ b/carsus_env3.yml
@@ -1,4 +1,4 @@
-name: carsus
+name: carsus_2020
 
 channels:
     - conda-forge


### PR DESCRIPTION
## Motivation
Trying to get Carsus to run automatically for elements up to uranium

## Changes
Added a fudge for when it doesn't get the ground level info from NIST - defaults to assuming g.s. J=0
Addition is in NIST/ionization.py
Currently it says "HELLO!" a lot, to prove to me that it's doing something. But probably should remove that..., following review!

Also - minor thing - seemed to need to add an extra line for when wanting to match to more than just energy and J. That's near start of gfall.py

## Description
When it finds a NaN for J, replace it with a zero.

